### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [2.0.0] - 2026-04-16
+
+### Dependency Updates
+
+- Update rust to v1.95.0 to v1.95.0 ([#115](https://github.com/joaolfp/releasor/pull/115))
+- Update Rust crate clap to v4.6.1 ([#114](https://github.com/joaolfp/releasor/pull/114))
+- Update Rust crate xx to v2.5.4 ([#113](https://github.com/joaolfp/releasor/pull/113))
+- Update Rust crate xx to v2.5.3 ([#106](https://github.com/joaolfp/releasor/pull/106))
+
+### Features
+
+- Add release-plz workflow and open-pr skill ([#97](https://github.com/joaolfp/releasor/pull/97))
+
+### Refactor
+
+- Move public methods before private in Cli impl and fix README badge formatting ([#103](https://github.com/joaolfp/releasor/pull/103))
+- Replace Status abstraction with xx crate and Result-based error handling ([#94](https://github.com/joaolfp/releasor/pull/94))
+
+### Chore
+
+- Add autofix.ci workflow and update README badges ([#99](https://github.com/joaolfp/releasor/pull/99))
+
+
+
 ## [1.7.0] - 2026-03-26
 
 ### Dependency Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [2.0.0] - 2026-06-30
+
+### Dependency Updates
+
+- Update Rust to v1.96.1 ([#121](https://github.com/joaolfp/releasor/pull/121))
+- Update Rust crate xx to v2.6.1 ([#118](https://github.com/joaolfp/releasor/pull/118))
+- Update Rust crate xx to v2.6.0 ([#117](https://github.com/joaolfp/releasor/pull/117))
+- Update rust to v1.96.0 to v1.96.0 ([#116](https://github.com/joaolfp/releasor/pull/116))
+- Update rust to v1.95.0 to v1.95.0 ([#115](https://github.com/joaolfp/releasor/pull/115))
+- Update Rust crate clap to v4.6.1 ([#114](https://github.com/joaolfp/releasor/pull/114))
+- Update Rust crate xx to v2.5.4 ([#113](https://github.com/joaolfp/releasor/pull/113))
+- Update Rust crate xx to v2.5.3 ([#106](https://github.com/joaolfp/releasor/pull/106))
+
+### Features
+
+- Add release-plz workflow and open-pr skill ([#97](https://github.com/joaolfp/releasor/pull/97))
+
+### Refactor
+
+- Move public methods before private in Cli impl and fix README badge formatting ([#103](https://github.com/joaolfp/releasor/pull/103))
+- Replace Status abstraction with xx crate and Result-based error handling ([#94](https://github.com/joaolfp/releasor/pull/94))
+
+### Chore
+
+- Add autofix.ci workflow and update README badges ([#99](https://github.com/joaolfp/releasor/pull/99))
+
+
+
 ## [1.7.0] - 2026-03-26
 
 ### Dependency Updates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,7 +797,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "releasor"
-version = "1.7.0"
+version = "2.0.0"
 dependencies = [
  "arboard",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "releasor"
-version = "1.7.0"
+version = "2.0.0"
 dependencies = [
  "arboard",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "releasor"
-version = "1.7.0"
+version = "2.0.0"
 edition = "2024"
 authors = ["João Lucas <joaolucasfp2001@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `releasor`: 1.7.0 -> 2.0.0 (⚠ API breaking changes)

### ⚠ `releasor` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  OutputCommand::cargo_release_output, previously in file /tmp/.tmpj9W6OP/releasor/src/output_command.rs:10
  OutputCommand::tar_output, previously in file /tmp/.tmpj9W6OP/releasor/src/output_command.rs:18
  OutputCommand::get_shasum_output, previously in file /tmp/.tmpj9W6OP/releasor/src/output_command.rs:32
  OutputCommand::cargo_release_output, previously in file /tmp/.tmpj9W6OP/releasor/src/output_command.rs:10
  OutputCommand::tar_output, previously in file /tmp/.tmpj9W6OP/releasor/src/output_command.rs:18
  OutputCommand::get_shasum_output, previously in file /tmp/.tmpj9W6OP/releasor/src/output_command.rs:32

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod releasor::status, previously in file /tmp/.tmpj9W6OP/releasor/src/status.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct releasor::status::Status, previously in file /tmp/.tmpj9W6OP/releasor/src/status.rs:3
  struct releasor::Status, previously in file /tmp/.tmpj9W6OP/releasor/src/status.rs:3
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.0] - 2026-06-30

### Dependency Updates

- Update Rust to v1.96.1 ([#121](https://github.com/joaolfp/releasor/pull/121))
- Update Rust crate xx to v2.6.1 ([#118](https://github.com/joaolfp/releasor/pull/118))
- Update Rust crate xx to v2.6.0 ([#117](https://github.com/joaolfp/releasor/pull/117))
- Update rust to v1.96.0 to v1.96.0 ([#116](https://github.com/joaolfp/releasor/pull/116))
- Update rust to v1.95.0 to v1.95.0 ([#115](https://github.com/joaolfp/releasor/pull/115))
- Update Rust crate clap to v4.6.1 ([#114](https://github.com/joaolfp/releasor/pull/114))
- Update Rust crate xx to v2.5.4 ([#113](https://github.com/joaolfp/releasor/pull/113))
- Update Rust crate xx to v2.5.3 ([#106](https://github.com/joaolfp/releasor/pull/106))

### Features

- Add release-plz workflow and open-pr skill ([#97](https://github.com/joaolfp/releasor/pull/97))

### Refactor

- Move public methods before private in Cli impl and fix README badge formatting ([#103](https://github.com/joaolfp/releasor/pull/103))
- Replace Status abstraction with xx crate and Result-based error handling ([#94](https://github.com/joaolfp/releasor/pull/94))

### Chore

- Add autofix.ci workflow and update README badges ([#99](https://github.com/joaolfp/releasor/pull/99))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).