### PR TITLE
refactor(tests): rename single-letter variable to descriptive name

### DIFF
--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -2,33 +2,39 @@ use releasor::Cli;
 
 #[test]
 fn validate_project_name_empty() {
-    let r = Cli::validate_project_name("");
-    assert!(r.is_err());
-    assert_eq!(r.unwrap_err(), "Project name can't be empty");
+    let validation_result = Cli::validate_project_name("");
+    assert!(validation_result.is_err());
+    assert_eq!(
+        validation_result.unwrap_err(),
+        "Project name can't be empty"
+    );
 }
 
 #[test]
 fn validate_project_name_whitespace_only() {
-    let r = Cli::validate_project_name("   ");
-    assert!(r.is_ok(), "trimmed empty is validated by caller");
+    let validation_result = Cli::validate_project_name("   ");
+    assert!(
+        validation_result.is_ok(),
+        "trimmed empty is validated by caller"
+    );
 }
 
 #[test]
 fn validate_project_name_contains_slash() {
-    let r = Cli::validate_project_name("foo/bar");
-    assert!(r.is_err());
+    let validation_result = Cli::validate_project_name("foo/bar");
+    assert!(validation_result.is_err());
     assert_eq!(
-        r.unwrap_err(),
+        validation_result.unwrap_err(),
         "Project name must not contain path separators"
     );
 }
 
 #[test]
 fn validate_project_name_contains_backslash() {
-    let r = Cli::validate_project_name("foo\\bar");
-    assert!(r.is_err());
+    let validation_result = Cli::validate_project_name("foo\\bar");
+    assert!(validation_result.is_err());
     assert_eq!(
-        r.unwrap_err(),
+        validation_result.unwrap_err(),
         "Project name must not contain path separators"
     );
 }


### PR DESCRIPTION
## ✨ Summary

- rename `r` to `validation_result` in `tests/cli_tests.rs` for readability

## 🔧 Type of Change

- [ ] ✨ Enhancement
- [ ] 🐞 Bug fix
- [ ] 🔐 Security fix
- [ ] 💥 Breaking change
- [ ] 🚀 New feature
- [ ] 📦 New release
- [ ] 📚 Documentation
- [x] ♻️ Refactor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only readability changes with no production or behavioral impact.
> 
> **Overview**
> Renames the temporary `r` binding to **`validation_result`** in the four `validate_project_name_*` tests in `tests/cli_tests.rs`, and splits a few `assert!` / `assert_eq!` calls across lines for readability.
> 
> Assertions and expected error strings are unchanged; **`validate_project_name_valid`** is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0172bf4daa0b34b8458d224ab9d48f9937e4dc0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->